### PR TITLE
fix navi befavior

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -3,6 +3,7 @@
     <navbar
       :current-user="current_user"
       @toggle-sidemenu="toggleSideMenu"
+      :rst-global-menu-btn-flg="rstGlobalMenuBtnFlg"
     ></navbar>
     <div id="body">
       <sidebar
@@ -14,6 +15,7 @@
         @open-form-board-edit="openFormBoardEdit"
         :trigger-menu-sp="isOpenSideMenuSp"
         :is-pc="isPC"
+        @touch-link-sp="resetGrobalMenuBtn"
       ></sidebar>
       <main>
         <div class="container">
@@ -117,7 +119,8 @@ export default {
       windowHeight: window.innerHeight,
       isOpenSideMenuSp: false,
       isPC: false,
-      breakPoint: 768
+      breakPoint: 768,
+      rstGlobalMenuBtnFlg: false
     }
   },
   components: {
@@ -214,6 +217,10 @@ export default {
     },
     toggleSideMenu: function(val) {
       this.isOpenSideMenuSp = val
+      this.rstGlobalMenuBtnFlg = false
+    },
+    resetGrobalMenuBtn: function() {
+      this.rstGlobalMenuBtnFlg = true
     }
   },
   beforeDestroy() {

--- a/app/javascript/packs/components/navbar.vue
+++ b/app/javascript/packs/components/navbar.vue
@@ -48,7 +48,23 @@ export default {
     currentUser: {
       type: Object,
       require: false
+    },
+    rstGlobalMenuBtnFlg: {
+      type: Boolean,
+      require: false,
+      default: false
     }
+  },
+  watch: {
+    'rstGlobalMenuBtnFlg': {
+      handler: function(newVal, oldVal) {
+        if (newVal && !oldVal && this.openFlg) {
+          this.toggleMenu()
+        }
+      },
+      deep: true,
+      immediate: true
+    },
   },
   data: function () {
     return {

--- a/app/javascript/packs/components/sidebar.vue
+++ b/app/javascript/packs/components/sidebar.vue
@@ -14,7 +14,7 @@
         </div>
         <ul class="menu-items">
           <li class="menu-items__item">
-            <router-link to="/" class="menu-items__item__link">
+            <router-link to="/" class="menu-items__item__link" @click.native="touchLink">
               <span class="icon"><i class="fas fa-home"></i></span>
               <span class="txt">HOME</span>
             </router-link>
@@ -35,7 +35,7 @@
             <ul class="projects">
               <li class="project" v-for="(item,index) in projects" v-bind:key="index">
                 <div class="project__head">
-                  <router-link :to="{ name: 'project', params: { id: item.id }}" class="project__head__link">
+                  <router-link :to="{ name: 'project', params: { id: item.id }}" class="project__head__link" @click.native="touchLink">
                     <div class="name">
                       <span class="icon_char">{{item.name[0]}}</span>
                       <span>{{item.name}}</span>
@@ -204,6 +204,11 @@ export default {
     toggleMenuSP: function() {
       if (window.innerWidth < this.breakPoint) {
         this.isOpenSidebar = this.triggerMenuSp
+      }
+    },
+    touchLink: function() {
+      if (!this.isPc) {
+        this.$emit('touch-link-sp')
       }
     }
   },


### PR DESCRIPTION
Fixed to close the side menu before route transition when clicking the side menu link in sp.


**Note:**
If you use v-on: click.native instead of v-on: click, it works fine.

_NG_
`<router-link :to="{ name: 'user', params: { userId: 123 }}" v-on:click="handleClick">User</router-link>`

_FINE_
`<router-link :to="{ name: 'user', params: { userId: 123 }}" v-on:click.native="handleClick">User</router-link>`