### PR TITLE
update member control in admin

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -30,18 +30,21 @@ class Admin::ProjectsController < AdminController
   def show
     @project = Project.find(params[:id])
     @members = @project.build_member
+    @board_owners = @project.get_board_owners
   end
 
   def edit
     @project = Project.find(params[:id])
     @members = @project.build_member
+    @checked_board_owner = @project.member_is_board_owner?(@members)
   end
 
   def update
     @project = Project.find(params[:id])
-
+    target_delete_members = @project.diff_member(project_params[:user_ids])
     if project_params[:user_ids] && @project.check_member(project_params[:workspace_id], project_params[:user_ids], project_member_params[:roles]) && @project.update(project_params)
-      success = true
+      # success = true
+      success = @project.delete_child (target_delete_members)
 
       @project.project_members.each do |member|
         index = project_params[:user_ids].index(member.user_id.to_s)

--- a/app/controllers/admin/workspaces_controller.rb
+++ b/app/controllers/admin/workspaces_controller.rb
@@ -28,18 +28,21 @@ class Admin::WorkspacesController < AdminController
   def show
     @workspace = Workspace.find(params[:id])
     @members = @workspace.build_member
+    @project_owners = @workspace.get_project_owners
+    @board_owners = @workspace.get_board_owners
   end
 
   def edit
     @workspace = Workspace.find(params[:id])
     @members = @workspace.build_member
+    @checked_project_or_board_owner = @workspace.member_is_project_or_board_owner?(@members)
   end
 
   def update
     @workspace = Workspace.find(params[:id])
-
+    target_delete_members = @workspace.diff_member(workspace_params[:user_ids])
     if workspace_params[:user_ids] && @workspace.check_member(workspace_params[:user_ids], workspace_member_params[:roles]) && @workspace.update(workspace_params)
-      success = true
+      success = @workspace.delete_child (target_delete_members)
 
       @workspace.workspace_members.each do |member|
         index = workspace_params[:user_ids].index(member.user_id.to_s)

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -38,7 +38,7 @@ class Api::BoardsController < ApplicationController
         end
       end
     else
-      @project = Project.joins(:users).select("projects.*, project_members.role").where(id: board.project_id, users: { id: current_user.id }).first
+      @project = Project.joins(:users).select("projects.*, project_members.role").where(id: @board.project_id, users: { id: current_user.id }).first
       if @project && @project.role_before_type_cast == 0
         render :show_pj_manager
       end

--- a/app/javascript/packs/components/modal/FormBoardEdit.vue
+++ b/app/javascript/packs/components/modal/FormBoardEdit.vue
@@ -85,7 +85,7 @@ export default {
       }
     },
     checkEnable: function() {
-      if (this.board.name && this.board.description) {
+      if (this.board.name /*&& this.board.description*/) {
         this.activeSubmit = true
       } else {
         this.activeSubmit = false

--- a/app/javascript/packs/components/modal/FormProjectEdit.vue
+++ b/app/javascript/packs/components/modal/FormProjectEdit.vue
@@ -93,7 +93,7 @@ export default {
       }
     },
     checkEnable: function() {
-      if (this.project.name && this.project.description) {
+      if (this.project.name /*&& this.project.description*/) {
         this.activeSubmit = true
       } else {
         this.activeSubmit = false

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -6,7 +6,7 @@ class Board < ApplicationRecord
   has_many :users, through: :board_members
 
   validates :name, presence: true, length: {maximum: 30}
-  validates :description, presence: true 
+  # validates :description, presence: true 
 
   def build_member
     members = []

--- a/app/models/workspace.rb
+++ b/app/models/workspace.rb
@@ -42,4 +42,73 @@ class Workspace < ApplicationRecord
   def instance_validations
     validates_with ::WorkspaceMemberValidator
   end
+
+  def get_project_owners
+    project_owners = []
+    self.projects.each do |project|
+      project_owners[project.id] = project.project_members.find { |member| member.role == 'owner' }.user
+    end
+    return project_owners
+  end
+
+  def get_board_owners
+    board_owners = []
+    self.projects.each do |project|
+      project.boards.each do |board|
+        board_owners[board.id] = board.board_members.find { |member| member.role == 'owner' }.user
+      end
+    end
+    return board_owners
+  end
+
+
+  def member_is_project_or_board_owner?(members)
+    project_owners = self.get_project_owners
+    board_owners = self.get_board_owners
+    
+    projects = self.projects
+    result = []
+    if !members.empty?
+      members.each do |member|
+        if project_owners.empty?
+          result[member.user_id] = false
+        else
+          result[member.user_id] = !project_owners.find { |owner| !owner.nil? && owner.id == member.user_id }.nil?
+          unless result[member.user_id]
+            result[member.user_id] = !board_owners.find { |owner| !owner.nil? && owner.id == member.user_id }.nil?
+          end
+        end
+      end
+    end
+    return result
+  end
+
+  def diff_member (new_ids)
+    current_ids = self.users.map { |user| user.id }
+    return current_ids - new_ids.map(&:to_i)
+  end
+
+  def delete_child (target_delete_members)
+    result = true
+    if !target_delete_members.empty?
+      self.projects.each do |project|
+        project.boards.each do |board|
+          target_delete_members.each do |target_delete_member|
+            bd_member = BoardMember.find_by(board_id: board.id, user_id: target_delete_member)
+            if bd_member && !bd_member.destroy
+              result = false
+            end
+          end
+        end
+        target_delete_members.each do |target_delete_member|
+          pj_member = ProjectMember.find_by(project_id: project.id, user_id: target_delete_member)
+          if pj_member && !pj_member.destroy
+            result = false
+          end
+        end
+      end
+     
+    end
+    return result
+  end
 end

--- a/app/views/admin/projects/_form.html.erb
+++ b/app/views/admin/projects/_form.html.erb
@@ -41,7 +41,13 @@
                 <td class="member-list__sel-user__authority">
                   <%= select_tag "project_member[roles][]", options_for_select(ProjectMember.roles, selected: member_info_pj.role_before_type_cast), {class: 'form-control', require: true} %>  
                 </td>
-                <td><span class="remove-member" data-user_id="<%= member_info_pj.user_id %>">削除</span></td>
+                <td>
+                  <% if  @checked_board_owner[member_info_pj.user_id] %>
+                    -
+                  <% else %>
+                    <span class="remove-member" data-user_id="<%= member_info_pj.user_id %>">削除</span>
+                  <% end %>
+                </td>
               </tr>
             <% end %>
           <% else %>

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -69,7 +69,7 @@
                     <% if !@project.boards.empty? %>
                       <ul style="padding-left: 0;">
                         <% @project.boards.each do |board| %>
-                          <li> - <%=link_to "#{board.name}", admin_board_path(board) %></li>
+                          <li> - <%=link_to "#{board.name} (owner: #{@board_owners[board.id].name})", admin_board_path(board)%></li> 
                         <% end %>
                       </ul>
                     <% else %>

--- a/app/views/admin/workspaces/_form.html.erb
+++ b/app/views/admin/workspaces/_form.html.erb
@@ -28,7 +28,13 @@
                 <td class="member-list__sel-user__authority">
                   <%= select_tag "workspace_member[roles][]", options_for_select(WorkspaceMember.roles, selected: member_info_ws.role_before_type_cast), {class: 'form-control', require: true} %>  
                 </td>
-                <td><span class="remove-member" data-user_id="<%= member_info_ws.user_id %>">削除</span></td>
+                <td>
+                  <% if @checked_project_or_board_owner[member_info_ws.user_id] %>
+                  -
+                  <% else %>
+                    <span class="remove-member" data-user_id="<%= member_info_ws.user_id %>">削除</span>
+                  <% end %>
+                </td>
               </tr>
             <% end %>
           <% else %>

--- a/app/views/admin/workspaces/show.html.erb
+++ b/app/views/admin/workspaces/show.html.erb
@@ -53,7 +53,19 @@
                     <% if !@workspace.projects.empty? %>
                       <ul style="padding-left: 0;">
                         <% @workspace.projects.each do |project| %>
-                          <li> - <%=link_to "#{project.name}", admin_project_path(project) %></li>
+                          <li>
+                             - <%=link_to "#{project.name}  (owner: #{@project_owners[project.id].name})", admin_project_path(project) %>
+                             <% if !project.boards.empty? %>
+                                <ul>
+                                  <% project.boards.each do |board| %>
+                                    <li>
+                                      |- <%=link_to "#{board.name} (owner: #{@board_owners[board.id].name})", admin_board_path(board) %>
+                                    </li>
+                                  <% end %>
+                                </ul>
+                                <br/>
+                             <% end %>
+                          </li>
                         <% end %>
                       </ul>
                     <% else %>

--- a/app/views/api/projects/show.json.jbuilder
+++ b/app/views/api/projects/show.json.jbuilder
@@ -1,5 +1,6 @@
 json.set! :project do
   json.extract! @project, :id, :name, :description, :created_at, :updated_at, :role, :workspace_id
+  json.join @projects_check_join
   json.set! :boards do
     json.array! @boards do |board|
       if board.project_id == @project.id


### PR DESCRIPTION
The following specifications are applied to member operations on the admin side.

1. When deleting a member of workspace, delete the member from the child project and grandchild board.
However, workspace members that have project owners or board owners as children cannot be deleted.
2. When deleting a member of project, delete the member from the child board as well.
However, project members whose children are board owners cannot be deleted.